### PR TITLE
Change description and link for conda integration

### DIFF
--- a/content/posts/2016/pytest-development-sprint.md
+++ b/content/posts/2016/pytest-development-sprint.md
@@ -26,7 +26,7 @@ Discussions:
 * what to include in pytest 3.0
 * advanced intro sessions on plugin mechanics (pluggy) and the fixture system implementation
 * tox roadmap
-* [Started to conceptualize generalize package builds and virtualenv creation](https://bitbucket.org/hpk42/tox/issues/338/generalize-package-builds-and-virtualenv)
+* [Started to conceptualize generalized package builds and virtualenv creation](https://bitbucket.org/hpk42/tox/issues/338/generalize-package-builds-and-virtualenv)
 * process for removing deprecated features
 * new 'fromcontext'/'invocation' scope for fixtures and some initial prototyping  
 * lightning talks

--- a/content/posts/2016/pytest-development-sprint.md
+++ b/content/posts/2016/pytest-development-sprint.md
@@ -26,7 +26,7 @@ Discussions:
 * what to include in pytest 3.0
 * advanced intro sessions on plugin mechanics (pluggy) and the fixture system implementation
 * tox roadmap
-* [making tox work with conda environments](https://bitbucket.org/nicoddemus/tox/branch/conda-tox-design)
+* [Started to conceptualize generalize package builds and virtualenv creation](https://bitbucket.org/hpk42/tox/issues/338/generalize-package-builds-and-virtualenv)
 * process for removing deprecated features
 * new 'fromcontext'/'invocation' scope for fixtures and some initial prototyping  
 * lightning talks


### PR DESCRIPTION
The conda integration is just one specific case of a more general concept. The link leads to the issue that collects related issues and links to the draft of the documentation.
